### PR TITLE
Remove process.exit from listen on error

### DIFF
--- a/apps/back-end/src/server/index.ts
+++ b/apps/back-end/src/server/index.ts
@@ -5,7 +5,6 @@ const port = parseInt(process.env.PORT ?? "8080");
 app.listen(parseInt(process.env.PORT ?? "8080"), (error) => {
   if (error) {
     console.error(error);
-    process.exit(1);
   } else {
     // eslint-disable-next-line no-console
     console.log(`Listening on port ${port}`);


### PR DESCRIPTION
In theory, I think what would do is, if an uncaught error comes up, it would shut down the back-end. I don't want the back-end to shut down completely if an error occurs, of course. The Sentry integration will come soon, once I set the fundamental rules of how endpoints in general work, but in any case, we should not be exiting on error.