### PR TITLE
Remove validation of POST body in test

### DIFF
--- a/apps/back-end/tests/server/users.test.ts
+++ b/apps/back-end/tests/server/users.test.ts
@@ -3,7 +3,7 @@ import type { ZodError } from "zod";
 
 import { randomUUID } from "crypto";
 
-import { parseAPIUser, parseUser, parseUserToPost } from "@neurosongs/prisma-client/types";
+import { parseAPIUser, parseUser } from "@neurosongs/prisma-client/types";
 import request from "supertest";
 import { userFactory } from "tests/test-utilities/dataFactory";
 import { describe, expect, test } from "vitest";
@@ -46,14 +46,14 @@ describe("/api/users", () => {
   });
   describe("POST", () => {
     test("201: Posts a user to the database and responds with the ID", async () => {
-      const user = parseUserToPost({
+      const user = {
         username: "alextheman",
         artistName: "Alex The Man",
         description: "I am an artist on Neurosongs",
         profilePicture: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         dateOfBirth: new Date("2003-07-16T00:00:00.000"),
         email: "alex@neurosongs.com",
-      });
+      };
 
       const {
         body: { userId },
@@ -64,13 +64,13 @@ describe("/api/users", () => {
       expect(postedUser).toMatchObject(user);
     });
     test("201: Allow optional properties to be left out", async () => {
-      const user = parseUserToPost({
+      const user = {
         username: "alextheman",
         artistName: "Alex The Man",
         profilePicture: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         dateOfBirth: new Date("2003-07-16T00:00:00.000"),
         email: "alex@neurosongs.com",
-      });
+      };
 
       const {
         body: { userId },


### PR DESCRIPTION
The POST endpoint should be the one responsible for validating the POST request body. The front-end is most likely not going to validate the request body itself since that tends to be more of a back-end responsibility. As such, it's more accurate to the actual flow if we don't validate the request body before sending it to the back-end, and just trust that the back-end will validate it in its own way.