### PR TITLE
Restrict access to import of @neurosongs/prisma-client

### DIFF
--- a/apps/back-end/eslint.config.js
+++ b/apps/back-end/eslint.config.js
@@ -14,6 +14,11 @@ export default [
               importNames: ["setPrismaClient"],
               message: "Do not attempt to reset the Prisma Client outside setup files.",
             },
+            {
+              // Do not allow imports from the generated types from PrismaClient. Instead use the processed Zod types from @neurosongs/types
+              name: "@neurosongs/prisma-client/types",
+              message: "Do not use the generated Prisma types. Use the types exported from @neurosongs/types instead."
+            }
           ],
         },
       ],

--- a/apps/front-end/eslint.config.js
+++ b/apps/front-end/eslint.config.js
@@ -1,3 +1,25 @@
-import plugin from "@alextheman/eslint-plugin"
+import plugin from "@alextheman/eslint-plugin";
 
-export default plugin.configs.alexTypeScriptReactBase
+export default [
+  ...plugin.configs.alexTypeScriptReactBase,
+  {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              /* Direct database queries from the front-end using the Prisma Client is generally bad practice, since
+                in theory, anyone with a modified version of the front-end, in a version that can query the database directly, can
+                send any sort of query, including ones that mutate data. It's a lot safer to keep database logic purely in the
+                back-end so that we can allow database writes in a controlled way. */
+              group: ["@neurosongs/prisma-client"],
+              message:
+                "Do not use the Prisma Client directly in the front-end. Query an endpoint from the back-end instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+];


### PR DESCRIPTION
The back-end gets everything except the generated types since it can instead rely on @neurosongs/types for all the Zod schemas and types. The front-end cannot access the Prisma client at all, since it's better practice to go through the back-end so it can apply extra validation that cannot be bypassed from the front-end.