### PR TITLE
Add clean install step to update-dependencies action

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         git config --global user.name "AlexUpBot"
         git config --global user.email "alexupbot@bot.com"
+    - name: Install dependencies
+      run: npm ci
     - name: Update dependencies
       run: npm run ci-update
     - name: Create Pull Request


### PR DESCRIPTION
Without this, it can't run turbo as is, which it needs to be able to do to update the dependencies to begin with.