### PR TITLE
Disable type-checking in generated files

### DIFF
--- a/apps/back-end/package.json
+++ b/apps/back-end/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run",
     "test-watch": "vitest",
     "format": "prettier --write --parser typescript \"src/**/*.ts\" \"tests/**/*.ts\" && eslint --fix --suppress-all \"src/**/*.ts\" \"tests/**/*.ts\" && rm -f eslint-suppressions.json",
-    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" && prettier --check --parser typescript \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts\" \"tests/**/*.ts\" && prettier --check --parser typescript \"src/**/*.ts\" \"tests/**/*.ts\"",
     "build": "tsup",
     "reset-database": "npx prisma migrate reset --force --skip-generate",
     "dev": "nodemon src/server/index.ts",

--- a/apps/front-end/package.json
+++ b/apps/front-end/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "format": "prettier --write --parser typescript \"src/**/*.{ts,tsx}\" && eslint --fix --suppress-all \"src/**/*.{ts,tsx}\" && rm -f eslint-suppressions.json",
-    "lint": "eslint \"src/**/*.{ts,tsx}\" && prettier --check --parser typescript \"src/**/*.{ts,tsx}\"",
+    "lint": "tsc --noEmit && eslint \"src/**/*.{ts,tsx}\" && prettier --check --parser typescript \"src/**/*.{ts,tsx}\"",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
     "clean-update": "bash ../../clean-update.sh",
     "preview": "vite preview"

--- a/packages/prisma-client/disableTscInFile.ts
+++ b/packages/prisma-client/disableTscInFile.ts
@@ -1,0 +1,3 @@
+import { disableTscInDirectory } from "@neurosongs/utility"
+
+disableTscInDirectory("src/generated")

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -27,7 +27,7 @@
     "generate": "prisma generate",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
     "clean-update": "bash ../../clean-update.sh",
-    "build": "rm -rf dist/generated && prisma generate && tsup && cp -r src/generated dist/generated",
+    "build": "rm -rf dist/generated && prisma generate && npx tsx disableTscInFile.ts && tsup && cp -r src/generated dist/generated",
     "format": "prisma format",
     "lint": "prisma format --check"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup",
     "format": "prettier --write --parser typescript \"src/**/*.ts\" \"*.ts\" && eslint --fix --suppress-all \"src/**/*.ts\" && rm -f eslint-suppressions.json",
-    "lint": "eslint \"src/**/*.ts\" && prettier --check --parser typescript \"src/**/*.ts\" \"*.ts\"",
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts\" && prettier --check --parser typescript \"src/**/*.ts\" \"*.ts\"",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
     "clean-update": "bash ../../clean-update.sh"
   },

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsup",
     "format": "prettier --write --parser typescript \"src/**/*.ts\" && eslint --fix --suppress-all \"src/**/*.ts\" && rm -f eslint-suppressions.json",
-    "lint": "eslint \"src/**/*.ts\" && prettier --check --parser typescript \"src/**/*.ts\"",
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts\" && prettier --check --parser typescript \"src/**/*.ts\"",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
     "clean-update": "bash ../../clean-update.sh"
   },

--- a/packages/utility/src/disableTscInDirectory.ts
+++ b/packages/utility/src/disableTscInDirectory.ts
@@ -1,0 +1,20 @@
+import { readdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import path from "path";
+
+function disableTscInDirectory(directory: string) {
+  const files = readdirSync(directory);
+
+  for (const file of files) {
+    const fullPath = path.join(directory, file);
+    if (statSync(fullPath).isDirectory()) {
+      disableTscInDirectory(fullPath);
+    } else if (file.endsWith(".ts")) {
+      const content = readFileSync(fullPath, "utf8");
+      if (!content.startsWith("// @ts-nocheck")) {
+        writeFileSync(fullPath, "// @ts-nocheck\n" + content, "utf8");
+      }
+    }
+  }
+}
+
+export default disableTscInDirectory;

--- a/packages/utility/src/index.ts
+++ b/packages/utility/src/index.ts
@@ -1,1 +1,2 @@
+export { default as disableTscInDirectory } from "src/disableTscInDirectory";
 export { default as parseDate } from "src/parseDate";


### PR DESCRIPTION
Since editing tsconfig never seems to work, a disableTscInDirectory script has to be added to manually added @ts-nocheck to the start of all generated files so that TypeScript does not type check these files.