### PR TITLE
Rename backed-up lockfile in clean-update script

### DIFF
--- a/clean-update.sh
+++ b/clean-update.sh
@@ -2,17 +2,17 @@
 
 REPOSITORY_ROOT="$(git rev-parse --show-toplevel)"
 CALL_DIRECTORY="$(pwd)"
-LOCKFILE="$REPOSITORY_ROOT/package-lock.json"
+LOCKFILE="$REPOSITORY_ROOT/package-lock"
 
 cd "$CALL_DIRECTORY"
 npx npm-check-updates -u
 
 if [[ "$CALL_DIRECTORY" == "$REPOSITORY_ROOT" ]]; then
-    cp "$LOCKFILE" "$LOCKFILE.backup.json"
+    cp "$LOCKFILE.json" "$LOCKFILE-backup.json"
     if ! npm install; then
         echo "npm install failed, restoring lockfile"
-        mv "$LOCKFILE.backup.json" "$LOCKFILE"
+        mv "$LOCKFILE-backup.json" "$LOCKFILE.json"
     else
-        rm -f "$LOCKFILE.backup.json"
+        rm -f "$LOCKFILE-backup.json"
     fi
 fi


### PR DESCRIPTION
Not a super important change, but previously the file was called package-lock.json.backup.json, which is a bit cursed. Now it's just package-lock-backup.json.