### PR TITLE
Install npm-check-updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/node": "^24.3.2",
         "eslint": "^9.35.0",
         "husky": "^9.1.7",
+        "npm-check-updates": "^18.1.1",
         "prettier": "^3.6.2",
         "turbo": "^2.5.6",
         "typescript": "5.9.2"
@@ -7461,6 +7462,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-check-updates": {
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.1.1.tgz",
+      "integrity": "sha512-sr+z5tEZop9n+uxAv/FVbpIdrayfG3Dr/D91igb+GyBl9eiudYUfGUZEBsmHq6kMOGEssSM3YWrP3njQjVU4Gw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "ncu": "build/cli.js",
+        "npm-check-updates": "build/cli.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0",
+        "npm": ">=8.12.1"
       }
     },
     "node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^24.3.2",
     "eslint": "^9.35.0",
     "husky": "^9.1.7",
+    "npm-check-updates": "^18.1.1",
     "prettier": "^3.6.2",
     "turbo": "^2.5.6",
     "typescript": "5.9.2"


### PR DESCRIPTION
This may be needed for the update-dependencies action to succeed, since I think it fails because it tries to run the update-dependencies script in all repository projects, and in CI, that means it tries to install npm-check-updates in all projects in the repository, which may've confused it and caused it to error.