### PR TITLE
Commit .env.test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,11 @@ jobs:
         cache: 'npm'
     - name: Initialise environment variables
       run: |
+        rm -f apps/back-end/.env.test
         touch apps/back-end/.env.test
         touch apps/back-end/.env.development
-        touch packages/prisma-client/.env
         echo DATABASE_URL="${{ secrets.DATABASE_URL }}" >> apps/back-end/.env.test
         echo DATABASE_URL="${{ secrets.DATABASE_URL }}" >> apps/back-end/.env.development
-        echo DATABASE_URL="${{ secrets.DATABASE_URL }}" >> packages/prisma-client/.env.test
     - name: Install dependencies
       run: npm ci
     - name: Generate Prisma Client

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules
 .env.test.local
 .env.production.local
 .env*
+# The local test database is likely to be the same across machines, assuming they use the same docker container,
+# so it is fine to use the database URL provided to save some setup.
+!.env.test
 
 # Testing
 coverage

--- a/apps/back-end/.env.test
+++ b/apps/back-end/.env.test
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://postgres:prisma@localhost:5432/tests?schema=public"


### PR DESCRIPTION
This saves a bit of setup since the local database URL is likely to be the same across machines assuming they use the same docker container to setup. As such, it is fine to commit this since it's easily reproducable anyway and it saves some setup time.